### PR TITLE
FORMIT-12249 Fixes web getting json string instead of payload like windows

### DIFF
--- a/v23_0/FormItInterface.js
+++ b/v23_0/FormItInterface.js
@@ -185,7 +185,7 @@ FormItInterface.Initialize = function(callbackMethod)
                         var msgHandlers = FormItInterface.MessageHandlers[jsonMessage.msg];
                         if (!!msgHandlers)
                         {
-                            msgHandlers.forEach((handler) => handler(event.data));
+                            msgHandlers.forEach((handler) => handler(jsonMessage.payload));
                         }
                     });
                     postRobot.FormItPluginMsgEventInitialized = true;


### PR DESCRIPTION
Not sure why the original web code was broadcasting the undecoded json string, but this should be fixed now. The problem is whether any plugins out in the wild used SubscribeMessage from this library to receive messages, writing their code around the raw json string. Thoughts?